### PR TITLE
Exception in dev env when only prod is set

### DIFF
--- a/lib/amgSentry.class.php
+++ b/lib/amgSentry.class.php
@@ -2,7 +2,7 @@
 
 /**
  * amgSentry allows you to send message and exception to Sentry.
- * 
+ *
  * @author Jean Roussel <jroussel@amg-dev.fr>
  * @copyright AMG Développement | Groupe GPdis
  *
@@ -35,9 +35,12 @@ class amgSentry extends Raven_Client {
 	* @param string $description Message description
 	* @param string $level Message level
 	*
-	* @return integer Sentry event ID 
+	* @return integer Sentry event ID
 	*/
 	static public function sendMessage($title, $description = '', $level = self::INFO){
+		if (!sfConfig::get('app_amg_sentry_enabled', false)) {
+			return true;
+		}
 		return self::getInstance()->captureMessage($title, array('description' => $description), $level);
 	}
 
@@ -47,9 +50,12 @@ class amgSentry extends Raven_Client {
 	* @param Exception $exception Exception
 	* @param string $description Exception description
 	*
-	* @return integer Sentry event ID 
+	* @return integer Sentry event ID
 	*/
 	static public function sendException($exception, $description = ''){
+		if (!sfConfig::get('app_amg_sentry_enabled', false)) {
+			return true;
+		}
 		return self::getInstance()->captureException($exception, $description);
 	}
 


### PR DESCRIPTION
Based on documented config:

``` yml
prod:
  amg_sentry:
    enabled: true
    dsn: 'http://public:secret@sentry.example.com:9000/[PROJECT_ID]'
    logger: 'custom-logger-name'
```

When:

``` php
amgSentry::sendMessage('Message title');
```

was called in dev env exception is throw:

``` php
throw new Exception('Please configure amgSentryPlugin in your app.yml (use model in "amgSentryPlugin/config/app.yml")');
```

Sorry for my bad English
