### PR TITLE
take the silence operator into account

### DIFF
--- a/lib/amgSentryErrorNotifierErrorHandler.php
+++ b/lib/amgSentryErrorNotifierErrorHandler.php
@@ -54,6 +54,9 @@ class amgSentryErrorNotifierErrorHandler
 	 */
 	public static function handlePhpError($errno, $errstr, $errfile, $errline)
 	{
+		if (error_reporting() === 0) {
+			return false;
+		}
 		$reportPHPWarnings = sfConfig::get('app_amg_sentry_reportPHPWarnings');
 
 		// there would be more warning codes but they are not caught by set_error_handler


### PR DESCRIPTION
When the silence operator is used, the error_reporting level is set to 0. Take it into account and don't send anything to Sentry.

This happens for instance [when the cache gets cleared](https://github.com/symfony/symfony1/blob/1.4/lib/cache/sfFileCache.class.php#L98). There are several calls to unlink with a silence operator before that generate tons of Sentry notifications.
